### PR TITLE
firmware.md.freifunk.net → CNAME web.md.freifunk.net

### DIFF
--- a/md.freifunk.net.zone
+++ b/md.freifunk.net.zone
@@ -28,7 +28,7 @@ gw2         A       46.232.249.208
 ;
 grafana     CNAME   web
 map         CNAME   web
-firmware    CNAME   web1
+firmware    CNAME   web
 ;
 fastd1      CNAME   gw1
 fastd2      CNAME   gw2

--- a/md.freifunk.net.zone
+++ b/md.freifunk.net.zone
@@ -1,7 +1,7 @@
 $ORIGIN md.freifunk.net.
 $TTL 86400
 @	SOA	ns1.md.freifunk.net.	abuse.md.freifunk.net. (
-		2022062601 ; serial
+		2022102401 ; serial
 		21600      ; refresh after 6 hours
 		3600       ; retry after 1 hour
 		604800     ; expire after 1 week


### PR DESCRIPTION
Part of moving the firmware from web1 to web.