### PR TITLE
Add entry for secondary name server

### DIFF
--- a/db.md.freifunk.net
+++ b/db.md.freifunk.net
@@ -14,6 +14,7 @@ $TTL 86400
 _dmarc      TXT     "v=DMARC1; p=reject; rua=kontakt@md.freifunk.net"
 ;
 ns1         A       5.252.224.201
+ns2	    A       5.45.104.191 ; tau.netz39.de
 ;
 web         A       5.252.224.201
             AAAA    2a03:4000:40:33f::1


### PR DESCRIPTION
This is not strictly needed, but allows to test the action to generate a serial number.