### PR TITLE
Fix main branch name for update-serial action

### DIFF
--- a/.github/workflows/update-serial.yml
+++ b/.github/workflows/update-serial.yml
@@ -3,7 +3,7 @@ name: Update and Tag DNS Zone Serial
 on:
   push:
     branches:
-      - "master"
+      - "main"
 
 jobs:
   build:


### PR DESCRIPTION
The update-serial action runs on the master branch, while this repository's primary branch is called main.